### PR TITLE
Fix generate command usage copy

### DIFF
--- a/cmd_generate.go
+++ b/cmd_generate.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	var outputFile string
 	var generateCmd = &cobra.Command{
-		Use:   "generate definition-folder template",
+		Use:   "generate definition template",
 		Short: "Generate source code from a template and remoto definition.",
 		Args:  cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {


### PR DESCRIPTION
From https://github.com/machinebox/remoto/issues/8 I'm presuming you removed the ability to code gen from a definition folder in favour of single files? Seems the usage description for the generate command wasn't updated to match.

Nice work on remoto btw 😄 